### PR TITLE
Adding omniauth

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -36,6 +36,10 @@ LineLength:
   Max: 140
   Enabled: true
 
+Style/DoubleNegation:
+  Exclude:
+    - app/controllers/application_controller.rb
+
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'figaro', '~> 1.1'
 gem 'mysql2'
 gem 'contracts'
 gem 'omniauth'
+gem 'omniauth-cas'
 
 group :development, :test do
   gem 'web-console', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'figaro', '~> 1.1'
 gem 'mysql2'
 gem 'contracts'
+gem 'omniauth'
 
 group :development, :test do
   gem 'web-console', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 ruby '2.2.2'
 
-gem 'rails-api'
+gem 'rails'
 gem 'jbuilder', '~> 2.0'
 gem 'figaro', '~> 1.1'
 gem 'mysql2'
@@ -29,10 +29,4 @@ group :documentation do
   gem 'yard'
   gem 'yard-contracts'
   gem 'yard-activerecord'
-end
-
-group :brakeman do
-  # A shim to help brakeman; Without this Brakeman detects that we
-  # are running Rails 3.x and that there are numerous vulnerabilites
-  gem 'rails', '~> 4.2', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'mysql2'
 gem 'contracts'
 gem 'omniauth'
 gem 'omniauth-cas'
+gem 'jwt'
 
 group :development, :test do
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       multi_json (>= 1.3)
       rake
     json (1.8.3)
+    jwt (1.5.1)
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -252,6 +253,7 @@ DEPENDENCIES
   contracts
   figaro (~> 1.1)
   jbuilder (~> 2.0)
+  jwt
   mysql2
   omniauth
   omniauth-cas

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.6)
       tilt
+    hashie (3.4.2)
     highline (1.6.21)
     i18n (0.7.0)
     jbuilder (2.3.1)
@@ -119,6 +120,9 @@ GEM
     net-ssh (2.9.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    omniauth (1.2.2)
+      hashie (>= 1.2, < 4)
+      rack (~> 1.0)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)
@@ -247,6 +251,7 @@ DEPENDENCIES
   figaro (~> 1.1)
   jbuilder (~> 2.0)
   mysql2
+  omniauth
   pry-byebug
   rails (~> 4.2)
   rails-api

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (6.0.2)
     ast (2.0.0)
     astrolabe (1.3.1)
@@ -123,6 +124,10 @@ GEM
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
+    omniauth-cas (1.1.0)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      omniauth (~> 1.2.0)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)
@@ -252,6 +257,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   mysql2
   omniauth
+  omniauth-cas
   pry-byebug
   rails (~> 4.2)
   rails-api

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,9 +152,6 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.3)
       sprockets-rails
-    rails-api (0.4.0)
-      actionpack (>= 3.2.11)
-      railties (>= 3.2.11)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.6)
@@ -259,8 +256,7 @@ DEPENDENCIES
   omniauth
   omniauth-cas
   pry-byebug
-  rails (~> 4.2)
-  rails-api
+  rails
   rspec-its
   rspec-rails
   shoulda-matchers

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ end
 
 ## API
 
+### GET /auth?after_authentication_callback_url=<cgi escaped URL>
+
+```console
+GET /auth?after_authentication_callback_url=https%3A%2F%2Fdeposit.library.nd.edu%2Fafter_authenticate
+```
+
+This resource is responsible for brokering the actual authentication service.
+Assuming a valid `after_authentication_callback_url`, it will respond with a 302 response (and redirect) to the CAS authentication service.
+If an invalid `after_authentication_callback_url` is provided, a 403 response will be given as a response.
+
 ### GET Agents
 
 #### Request
@@ -117,6 +127,7 @@ It was also clear that our institutional service was inadequate due to the natur
   * Unverified group - What does this mean?
 * Authentication
   * ~~Campus Authentication Service (CAS)~~
+  * ~~Handle a request for Cogitate to broker the authentication~~
   * Passback a ticket to the primary application
 
 ### Phase 2

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ It was also clear that our institutional service was inadequate due to the natur
   * ~~Verified group~~
   * Unverified group - What does this mean?
 * Authentication
-  * Campus Authentication Service (CAS)
+  * ~~Campus Authentication Service (CAS)~~
+  * Passback a ticket to the primary application
 
 ### Phase 2
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,33 @@
+require 'cogitate/interfaces'
 # The base controller for Cogitate
-class ApplicationController < ActionController::API
-  def self.protect_from_forgery(*)
+class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+
+  private
+
+  def signed_in?
+    !!current_user
   end
-  protect_from_forgery with: :null_session
+
+  include Contracts
+  Contract(None => Or[Cogitate::Interfaces::IdentifierInterface, Eq[false]])
+  def current_user
+    @current_user ||=
+    if session.key?(:user_identifying_value) && session.key?(:user_strategy)
+      Identifier.new(strategy: session.fetch(:user_strategy), identifying_value: session.fetch(:user_identifying_value))
+    else
+      false
+    end
+  end
+
+  Contract(Cogitate::Interfaces::IdentifierInterface => Any)
+  def current_user=(identifier)
+    @current_user = identifier
+    # The session does not allow nested hashes, so I'm breaking it apart
+    session[:user_strategy] = identifier.base_strategy
+    session[:user_identifying_value] = identifier.base_identifying_value
+    @current_user
+  end
+
+  helper_method :signed_in?, :current_user
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,28 @@
+require 'identifier'
+
+# Responsible for negotiating session authentication
+class SessionsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  # @todo All callbacks point to this single action. Is that the correct behavior?
+  def create
+    self.current_user = Identifier.new(strategy: strategy, identifying_value: identifying_value)
+    redirect_to "/api/agents/#{current_user.encoded_id}"
+  end
+
+  private
+
+  def identifying_value
+    auth_hash.fetch('uid')
+  end
+
+  PROVIDER_TO_STRATEGY = { 'cas' => 'netid', 'developer' => 'email' }.freeze
+  def strategy
+    provider = auth_hash.fetch('provider')
+    PROVIDER_TO_STRATEGY.fetch(provider, provider)
+  end
+
+  def auth_hash
+    request.env['omniauth.auth']
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,10 +3,31 @@ require 'identifier'
 # Responsible for negotiating session authentication
 class SessionsController < ApplicationController
   skip_before_action :verify_authenticity_token
+  QUERY_KEY_FOR_AFTER_AUTHENTICATION_CALLBACK_URL =  :after_authentication_callback_url
+  FORBIDDEN_TEXT_FOR_NEW = "FORBIDDEN: Expected query parameter 'after_authentication_callback_url' to be a CGI escaped Secure URL".freeze
+
+  # @api public
+  #
+  # This action is the external API end point for brokered authentication via Cogitate.
+  # It is responsible for ensuring a well-formed brokerable request and remembering relevant after authentication information.
+  #
+  # @todo For now, Cogitate is making the decision that all authentication happens via CAS
+  #    Eventually we may introduce a point for a human to make a decision.
+  def new
+    contraint_handler = NewActionConstraintHandler.new(controller: self, query_key: QUERY_KEY_FOR_AFTER_AUTHENTICATION_CALLBACK_URL)
+    if contraint_handler.valid?
+      session[QUERY_KEY_FOR_AFTER_AUTHENTICATION_CALLBACK_URL] = contraint_handler.after_authentication_callback_url
+      redirect_to '/auth/cas'
+    else
+      render text: FORBIDDEN_TEXT_FOR_NEW, status: :forbidden
+    end
+  end
 
   # @todo All callbacks point to this single action. Is that the correct behavior?
   def create
     self.current_user = Identifier.new(strategy: strategy, identifying_value: identifying_value)
+    # Generate the Agent token for this identifier
+    # Redirect back to the after_authenticate URL that is stored in the session
     redirect_to "/api/agents/#{current_user.encoded_id}"
   end
 
@@ -24,5 +45,33 @@ class SessionsController < ApplicationController
 
   def auth_hash
     request.env['omniauth.auth']
+  end
+
+  # @api private
+  class NewActionConstraintHandler
+    def initialize(controller:, query_key: SessionsController::QUERY_KEY_FOR_AFTER_AUTHENTICATION_CALLBACK_URL)
+      self.controller = controller
+      self.query_key = query_key
+      set_after_authentication_callback_url!
+    end
+
+    def valid?
+      return false if @after_authentication_callback_url.blank?
+      return false if @after_authentication_callback_url !~ %r{^https://}
+      true
+    end
+
+    def after_authentication_callback_url
+      return @after_authentication_callback_url if valid?
+      fail "#{@after_authentication_callback_url.inspect} is not a valid URL for an after authentication callback"
+    end
+
+    private
+
+    def set_after_authentication_callback_url!
+      @after_authentication_callback_url = CGI.unescape(controller.params.fetch(query_key, ''))
+    end
+
+    attr_accessor :controller, :query_key
   end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -12,10 +12,11 @@ class Agent
   # @note I'm choosing the :identifier as the input and :primary_identifier as the attribute. I believe it is possible that during the
   #       process that builds the Agent, I may encounter a more applicable primary_identifier.
   Contract(Contracts::KeywordArgs[identifier: Cogitate::Interfaces::IdentifierInterface] => Cogitate::Interfaces::AgentInterface)
-  def initialize(identifier:, container: default_container)
+  def initialize(identifier:, container: default_container, serializer_builder: default_serializer_builder)
     self.identities = container.new
     self.verified_authentication_vectors = container.new
     self.primary_identifier = identifier
+    self.serializer = serializer_builder.call(agent: self)
     self
   end
 
@@ -32,6 +33,7 @@ class Agent
 
   extend Forwardable
   def_delegators :primary_identifier, :strategy, :identifying_value
+  def_delegators :serializer, :to_builder, :as_json
 
   JSON_API_TYPE = 'agents'.freeze
   def type
@@ -54,5 +56,11 @@ class Agent
   def default_container
     require 'set' unless defined?(Set)
     Set
+  end
+
+  attr_accessor :serializer
+  def default_serializer_builder
+    require 'agent/serializer' unless defined?(Agent::Serializer)
+    Agent::Serializer.method(:new)
   end
 end

--- a/app/models/agent/serializer.rb
+++ b/app/models/agent/serializer.rb
@@ -1,0 +1,43 @@
+require 'jbuilder'
+require 'cogitate/interfaces'
+
+class Agent
+  # Responsible for the serialization of an Agent
+  class Serializer
+    # include Contracts
+    # Contract(Cogitate::Interfaces::AgentInterface => RespondTo[:to_builder])
+    def initialize(agent:)
+      self.agent = agent
+      self
+    end
+
+    private
+
+    attr_accessor :agent
+
+    public
+
+    def as_json(*)
+      {
+        'type' => agent.type,
+        'id' => agent.id,
+        'attributes' => { 'strategy' => agent.strategy, 'identifying_value' => agent.identifying_value },
+        'relationships' => { 'identities' => identities_as_json, 'verified_identities' => verified_identities_as_json }
+      }
+    end
+
+    private
+
+    def identities_as_json
+      agent.identities.each_with_object([]) do |identity, mem|
+        mem << { 'type' => identity.strategy, 'id' => identity.identifying_value, 'attributes' => identity.as_json }
+      end
+    end
+
+    def verified_identities_as_json
+      agent.verified_authentication_vectors.each_with_object([]) do |identity, mem|
+        mem << { 'type' => identity.strategy, 'id' => identity.identifying_value, 'attributes' => identity.as_json }
+      end
+    end
+  end
+end

--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -32,10 +32,6 @@ class Identifier
   # @return [String]
   alias_method :base_strategy, :strategy
 
-  def attribute_keys
-    []
-  end
-
   def as_json(*)
     {}
   end

--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -36,6 +36,10 @@ class Identifier
     []
   end
 
+  def as_json(*)
+    {}
+  end
+
   include Comparable
 
   # @api public

--- a/app/models/identifier/unverified.rb
+++ b/app/models/identifier/unverified.rb
@@ -21,6 +21,10 @@ class Identifier
       []
     end
 
+    def as_json(*)
+      {}
+    end
+
     extend Forwardable
     include Comparable
     def_delegators :identifier, :<=>, :identifying_value, :base_strategy, :base_identifying_value

--- a/app/models/identifier/unverified.rb
+++ b/app/models/identifier/unverified.rb
@@ -17,10 +17,6 @@ class Identifier
       false
     end
 
-    def attribute_keys
-      []
-    end
-
     def as_json(*)
       {}
     end

--- a/app/models/identifier/verified.rb
+++ b/app/models/identifier/verified.rb
@@ -11,7 +11,7 @@ class Identifier
     # @return Class
     def self.build_named_strategy(*given_attribute_keys)
       Class.new do
-        class_attribute :attribute_keys
+        class_attribute :attribute_keys, instance_predicate: false, instance_writer: false
         self.attribute_keys = given_attribute_keys.freeze
 
         define_method :initialize do |identifier:, attributes:|

--- a/app/models/identifier/verified.rb
+++ b/app/models/identifier/verified.rb
@@ -23,6 +23,13 @@ class Identifier
           self
         end
 
+        define_method :as_json do |*|
+          attribute_keys.each_with_object({}) do |key, mem|
+            mem[key] = send(key)
+            mem
+          end
+        end
+
         define_method(:verified?) { true }
         define_method(:strategy) { "verified/#{identifier.strategy}" }
 

--- a/app/services/cogitate/services/agent_tokenizer.rb
+++ b/app/services/cogitate/services/agent_tokenizer.rb
@@ -1,0 +1,62 @@
+require 'cogitate/interfaces'
+require 'figaro'
+require 'jwt'
+
+module Cogitate
+  module Services
+    # Responsible for serializing an Agent to JSON and encoding that JSON using JSON Web Token
+    # encoding (jwt).
+    class AgentTokenizer
+      # @api public
+      def self.call(agent:, **keywords)
+        new(agent: agent, **keywords).call
+      end
+
+      def initialize(agent:, **keywords)
+        self.agent = agent
+        self.encryption_type = keywords.fetch(:encryption_type) { default_encryption_type }
+        self.password = keywords.fetch(:password) { default_password }
+        self.issuer_claim = keywords.fetch(:issuer_claim) { default_issuer_claim }
+      end
+
+      # @api public
+      #
+      # @return [String] An encoded (and perhaps encrypted) string. It is decodable (and decryptable) via the jwt gem.
+      # @see https://github.com/jwt/ruby-jwt
+      def call
+        JWT.encode(payload, coerced_password, encryption_type)
+      end
+
+      private
+
+      # @api private
+      def payload
+        { data: agent.as_json, iss: issuer_claim }
+      end
+
+      # I need to coerce the password into the correct format.
+      def coerced_password
+        case encryption_type.to_s
+        when /\ARS\d/i
+          OpenSSL::PKey::RSA.new(password)
+        else
+          encryption_type
+        end
+      end
+
+      attr_accessor :agent, :password, :encryption_type, :issuer_claim
+
+      def default_password
+        Figaro.env.agent_tokenizer_private_password
+      end
+
+      def default_encryption_type
+        Figaro.env.agent_tokenizer_encryption_type
+      end
+
+      def default_issuer_claim
+        Figaro.env.agent_tokenizer_issuer_claim
+      end
+    end
+  end
+end

--- a/app/services/cogitate/services/identifier_to_agent_encoder.rb
+++ b/app/services/cogitate/services/identifier_to_agent_encoder.rb
@@ -3,6 +3,11 @@ module Cogitate
     # This class is responsible for:
     # * Convertin an Identifier to a corresponding Agent, then encoding that Agent as a JSON Web Token
     class IdentifierToAgentEncoder
+      # @api public
+      def self.call(identifier:, **keywords)
+        new(identifier: identifier, **keywords).call
+      end
+
       def initialize(identifier:, agent_extractor: default_agent_extractor, agent_tokenizer: default_agent_tokenizer)
         self.identifier = identifier
         self.agent_extractor = agent_extractor

--- a/app/services/cogitate/services/identifier_token_encoder.rb
+++ b/app/services/cogitate/services/identifier_token_encoder.rb
@@ -1,0 +1,32 @@
+module Cogitate
+  module Services
+    # This class is responsible for:
+    # * Convertin an Identifier to a corresponding Agent, then encoding that Agent as a JSON Web Token
+    class IdentifierToAgentEncoder
+      def initialize(identifier:, agent_extractor: default_agent_extractor, agent_tokenizer: default_agent_tokenizer)
+        self.identifier = identifier
+        self.agent_extractor = agent_extractor
+        self.agent_tokenizer = agent_tokenizer
+      end
+
+      def call
+        agent = agent_extractor.call(identifier: identifier)
+        agent_tokenizer.call(agent: agent)
+      end
+
+      private
+
+      attr_accessor :identifier, :agent_extractor, :agent_tokenizer
+
+      def default_agent_extractor
+        require 'cogitate/services/agent_extractor' unless defined?(Cogitate::Services::AgentExtractor)
+        Cogitate::Services::AgentExtractor
+      end
+
+      def default_agent_tokenizer
+        require 'cogitate/services/agent_tokenizer' unless defined?(Cogitate::Services::AgentTokenizer)
+        Cogitate::Services::AgentTokenizer
+      end
+    end
+  end
+end

--- a/app/views/api/agents/index.json.jbuilder
+++ b/app/views/api/agents/index.json.jbuilder
@@ -2,30 +2,4 @@ json.links do
   json.self request.url
 end
 
-json.data(@agents) do |agent|
-  json.type agent.type
-  json.id agent.id
-
-  json.attributes do
-    json.strategy agent.strategy
-    json.identifying_value agent.identifying_value
-  end
-
-  json.relationships do
-    json.identities(agent.identities) do |identity|
-      json.type identity.strategy
-      json.id identity.identifying_value
-      json.attributes do
-        json.(identity, *identity.attribute_keys)
-      end
-    end
-
-    json.verified_identities(agent.verified_authentication_vectors) do |identity|
-      json.type identity.strategy
-      json.id identity.identifying_value
-      json.attributes do
-        json.(identity, *identity.attribute_keys)
-      end
-    end
-  end
-end
+json.data(@agents)

--- a/config/application.yml
+++ b/config/application.yml
@@ -10,6 +10,7 @@ hesburgh_api_host: https://api.library.nd.edu/
 protocol: 'http'
 airbrake_api_key: 'this-makes-no-sense'
 airbrake_host: 'errbit.library.nd.edu'
+omniauth_cas_url: 'https://cas.library.nd.edu/cas'
 
 development:
   domain_name: "localhost:3000"

--- a/config/application.yml
+++ b/config/application.yml
@@ -5,19 +5,16 @@
 # development.
 #
 # They are included so we can share what the keys should be.
-hesburgh_api_auth_token: '12345'
-hesburgh_api_host: https://api.library.nd.edu/
-protocol: 'http'
+agent_tokenizer_encryption_type: 'RS256'
+agent_tokenizer_private_password: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpgIBAAKCAQEAw1/5K82tppY/rlLZhflSDp9qY6l04gLFJmio0K1SfkAfDQWU\nxgua4TbpHMZePgkgVwBjajJPFgCJbqNCbJh7qpTXw6c89KnBb2qYloQq0CLkS+Df\nNBKe3wzVVgfhQ97EGV3ct1bXpwYcNOzKB390imghxHBu7lTU8kUbY4BlKd8ykVJY\n4lM3FN5VHqX9lq6IbVZ09qkwNY+idVmu4o0aHYIfyOYeAvYqVQO3LBbaZcb0gzwY\nFHCX61LuFFwLoTt/AdfXMbeQmBTyEGjZH7+1vDfb49iq0DWn4jQbl5XHxKsv5tUi\n5L2MKpmkbtneCDlnOIKIxexv6Cv8gGvBAUAHxwIDAQABAoIBAQCsplEQzm8X+UpJ\nCFnFNK+40FM5wvPRDdWevXoA/kkZ3BwUa8wuvu6c+uNBVGLPu0zi1SsFG3Qb41mP\ndaIrSQxvj5yj/1O0eZbAmJhC2oTi7RKFozBbWeEfBr43ijscuOzd5b44HfvwU0v1\n0RIvUghwjtjYOOsunbSYa01qvnmnZ1JkS6wVf9WgEO6xcmVo6IMuA/4e/BCtcLaW\nwTGE71xeSZZY+luXYwu3jzwK3iJcrbtB5Ldj3LbgZDg5mCa9FOvgj+hZM8zd2KzC\n6GzmInpmG6/OlaXO6j9rSG6+K94JU99Da9I07bjK20MmmMVDu/ZC/BIYbCWUi+uU\nEhq9kjvxAoGBAPg3ZZx7lqaQrVGp2fyIty+cZ8jppSz5MI41noCdxpcQwO5QkWh2\nmH9+nPU4BIKOEK5zxEsSTiP/jIFVTW/5ZQU2pW12LcjEeNzEpj65Hy7NrkPdDn9u\nhYx4Zklf/fQD0DOwHG7ZRgsOY9TuTCkyiCHvTJQgtTnGIeRSG+9gHYutAoGBAMmA\nYalKmNWUj9ypXiDQO2Jw+qRLEVQGN0u8SedZGKdlPcqLTwoucIUIMmMZ5DB0KBJF\n9k40JVuvCyQKkFN5iCASYhY8c9r34FJjEV2gojRW5IVRg4EJXn9FYYgIP5rd9ZoY\nEOZTzTvZgcUP2ks/gpnDcxfWhyqsH9wU94g3vY/DAoGBAIdLWr1iuAjuTyp2FHWL\n552x+PgQMpJC+W5qV4zvcvGglijQDZINIq5Lyy32bK7k1L7iJxpsTd9dSa6tWlow\nbBndYWo6wlXukZp0LdF+gjq2rcgb0+0txul8LvTLt9arxW6HDdh14bHhFBVaFnVW\nL9GfZ/RNp7pn/s0+3C8sCq65AoGBAIcXvWIkkybOPU0xd9wD/2xWVpQDiBCPQk9S\nYzHpt++ynqTGlS08SU/HWRC78RLTLXJi2WlA6LL5PjzhoDV2y17FNGG4EeyCNzDF\nHoVpBpaUkw0Ww1WllGc7etIaxZnsqZav/9SL5pLzll8p6657W/H+6ZDX0TM4xvtk\nSzhWNo7FAoGBALHwvJCz1vOl2gAllJPFI3Pg6m/V8q1lHT+DXiK4emEcDFHovnf6\nwMpgKa+M5VeX4USeLXCRMNUm3ithQK/N1uXPQNY7Y/qFNO/qefExQnO53CBkVcXv\nkYGFoOWpJPKdx7uR/9rf1EQvoiaXBSHlnBjRBdeoMVXo0mtM1iiSoM+H\n-----END RSA PRIVATE KEY-----\n"
+agent_tokenizer_public_password: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuZYpQKfFJ2CfdyPTMj7b\nQBALe58cWAN+B6tyLBPozDRe7OcJPs/PnOtaPcvdk0RQcTxCtTkgb3Z1bTeQam+l\n3Hy5byCXcojCQPbQes+jGQ62W59aC6li/v0QakO68kCr/HAI49HBhMp59LOVNWUQ\nZNIgnbQxWT3N/0guLPbN2d+qTSW906YRjanVE4daKQ0TNZKa8Py1PP8ey0h2ipoW\nkr0WAz24AgdXUkQ4Y1RdeEs71On5exx8WtrUBMluNIG4neJwvkiaXWMDS2eQU2Oy\nV/L1dkNUrpnNuUb3vhlfyTKEsYUpt0ZoMVyddL1Vzuw/GmGuc4a1y+P6rmHXxQJR\n7wIDAQAB\n-----END PUBLIC KEY-----\n"
+agent_tokenizer_issuer_claim: "https://library.nd.edu"
 airbrake_api_key: 'this-makes-no-sense'
 airbrake_host: 'errbit.library.nd.edu'
+domain_name: "localhost:3000"
+hesburgh_api_auth_token: '12345'
+hesburgh_api_host: https://api.library.nd.edu/
 omniauth_cas_url: 'https://cas.library.nd.edu/cas'
-
-development:
-  domain_name: "localhost:3000"
-  url_host: "http://localhost:3000"
-  secret_key_base: '31fdea52df67b6f29cdd3b4ca0943b2baf696eb164fa5ed92858f4a66d142668a8a29c0bdccc46575c063de687ad456f58b4022f9ffde186ead80c0d292f500a'
-
-test:
-  domain_name: "localhost:3000"
-  url_host: "http://localhost:3000"
-  secret_key_base: '31fdea52df67b6f29cdd3b4ca0943b2baf696eb164fa5ed92858f4a66d142668a8a29c0bdccc46575c063de687ad456f58b4022f9ffde186ead80c0d292f500a'
+protocol: 'http'
+secret_key_base: '31fdea52df67b6f29cdd3b4ca0943b2baf696eb164fa5ed92858f4a66d142668a8a29c0bdccc46575c063de687ad456f58b4022f9ffde186ead80c0d292f500a'
+url_host: "http://localhost:3000"

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,0 +1,9 @@
+Figaro.require_keys(
+  'agent_tokenizer_encryption_type',
+  'agent_tokenizer_private_password',
+  'agent_tokenizer_public_password',
+  'agent_tokenizer_issuer_claim',
+  'hesburgh_api_auth_token',
+  'hesburgh_api_host',
+  'omniauth_cas_url'
+)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,6 @@
+OmniAuth.config.logger = Rails.logger
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :developer if Rails.env.test? || Rails.env.development?
+  provider :cas, url: Figaro.env.omniauth_cas_url!
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     get 'agents/:urlsafe_base64_encoded_identifiers', to: 'agents#index'
   end
 
+  get '/auth', to: 'sessions#new'
+
   get '/auth/:provider/callback', to: 'sessions#create'
   if Rails.env.test? || Rails.env.development?
     post '/auth/developer/callback', to: 'sessions#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,9 @@ Rails.application.routes.draw do
     # It does mean that you need to be mindful of escaping identifiers with / in them
     get 'agents/:urlsafe_base64_encoded_identifiers', to: 'agents#index'
   end
+
+  get '/auth/:provider/callback', to: 'sessions#create'
+  if Rails.env.test? || Rails.env.development?
+    post '/auth/developer/callback', to: 'sessions#create'
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController do
+  let(:identifier) { Identifier.new(strategy: 'email', identifying_value: 'hello@world.com') }
+  context '#current_user=' do
+    it 'will set the session based on the input' do
+      expect { controller.send(:current_user=, identifier) }.to(
+        change { controller.session.keys }.from([]).to(['user_strategy', 'user_identifying_value'])
+      )
+    end
+
+    it 'will set an instance variable' do
+      expect { controller.send(:current_user=, identifier) }.to(
+        change { controller.instance_variable_get(:@current_user) }.from(nil).to(identifier)
+      )
+    end
+  end
+
+  context '#current_user' do
+    it 'will reconstitute an identifier from the session' do
+      controller.session[:user_strategy] = identifier.base_strategy
+      controller.session[:user_identifying_value] = identifier.base_identifying_value
+      expect(controller.send(:current_user)).to eq(identifier)
+    end
+
+    it 'will be false if no session information is set' do
+      expect(controller.send(:current_user)).to eq(false)
+    end
+
+    it 'will reuse the instance variable' do
+      controller.instance_variable_set(:@current_user, identifier)
+      expect(controller.send(:current_user)).to eq(identifier)
+    end
+  end
+
+  context '#signed_in?' do
+    it 'will be true if @current_user is an Identifier' do
+      controller.instance_variable_set(:@current_user, identifier)
+      expect(controller.send(:signed_in?)).to eq(true)
+    end
+
+    it 'will be false if @current_user is false' do
+      expect(controller.send(:signed_in?)).to eq(false)
+    end
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,13 +2,61 @@ require 'rails_helper'
 require 'identifier'
 
 RSpec.describe SessionsController do
-  context '#create' do
+  context 'GET #new' do
+    let(:the_after_authentication_callback_url) { 'http://google.com' }
+
+    it "will return a 403 (Forbidden) when handling an invalid request" do
+      allow_any_instance_of(described_class::NewActionConstraintHandler).to receive(:valid?).and_return(false)
+      get :new, after_authentication_callback_url:  CGI.escape(the_after_authentication_callback_url)
+      expect(response).to have_http_status(403)
+      expect(response.body).to eq(described_class::FORBIDDEN_TEXT_FOR_NEW)
+    end
+
+    it "will redirect to the /auth/cas route and store the after_authentication_callback_url" do
+      allow_any_instance_of(described_class::NewActionConstraintHandler).to receive(:valid?).and_return(true)
+      get :new, after_authentication_callback_url: CGI.escape(the_after_authentication_callback_url)
+      expect(response).to have_http_status(302)
+      expect(response).to redirect_to('/auth/cas')
+      expect(controller.session[:after_authentication_callback_url]).to eq(the_after_authentication_callback_url)
+    end
+  end
+  context 'GET #create' do
     context 'with valid data' do
       let(:identifier) { Identifier.new(strategy: 'email', identifying_value: 'jfriesen') }
       it 'will assign the current user' do
         controller.request.env['omniauth.auth'] = { 'uid' => identifier.base_identifying_value, 'provider' => identifier.base_strategy }
         get :create
         expect(controller.send(:current_user)).to eq(identifier)
+      end
+    end
+  end
+end
+
+class SessionsController
+  RSpec.describe NewActionConstraintHandler do
+    [
+      { params: { after_authentication_callback_url: 'https://google.com' }, valid?: true, callback_url: 'https://google.com' },
+      { params: { after_authentication_callback_url: CGI.escape('https://google.com') }, valid?: true, callback_url: 'https://google.com' },
+      { params: { after_authentication_callback_url: '/hello' }, valid?: false, callback_url: RuntimeError },
+      { params: { after_authentication_callback_url: '' }, valid?: false, callback_url: RuntimeError },
+      { params: { after_authentication_callback_url: CGI.escape('http://google.com') }, valid?: false, callback_url: RuntimeError },
+      { params: {}, valid?: false, callback_url: RuntimeError }
+    ].each do |test_case|
+      it "will have #valid? == #{test_case.fetch(:valid?)} for params #{test_case.fetch(:params).inspect}" do
+        controller = double(params: test_case.fetch(:params))
+        subject = described_class.new(controller: controller)
+        expect(subject.valid?).to eq(test_case.fetch(:valid?))
+      end
+
+      it "will have an after_authentication_callback_url of #{test_case[:callback_url].inspect} for params #{test_case[:params].inspect}" do
+        controller = double(params: test_case.fetch(:params))
+        subject = described_class.new(controller: controller)
+        expected_response = test_case.fetch(:callback_url)
+        if expected_response == RuntimeError
+          expect { subject.after_authentication_callback_url }.to raise_error(expected_response)
+        else
+          expect(subject.after_authentication_callback_url).to eq(expected_response)
+        end
       end
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+require 'identifier'
+
+RSpec.describe SessionsController do
+  context '#create' do
+    context 'with valid data' do
+      let(:identifier) { Identifier.new(strategy: 'email', identifying_value: 'jfriesen') }
+      it 'will assign the current user' do
+        controller.request.env['omniauth.auth'] = { 'uid' => identifier.base_identifying_value, 'provider' => identifier.base_strategy }
+        get :create
+        expect(controller.send(:current_user)).to eq(identifier)
+      end
+    end
+  end
+end

--- a/spec/models/agent/serializer_spec.rb
+++ b/spec/models/agent/serializer_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_fast_helper'
+require 'identifier'
+require 'agent'
+require 'agent/serializer'
+require 'json'
+
+RSpec.describe Agent::Serializer do
+  let(:identifier) { Identifier.new(strategy: 'netid', identifying_value: 'hello') }
+  let(:agent) { Agent.new(identifier: identifier) }
+  subject { described_class.new(agent: agent) }
+
+  its(:to_json) { should be_a(String) }
+
+  context '#as_json' do
+    before do
+      agent.identities << identifier
+      agent.verified_authentication_vectors << identifier
+    end
+    it 'will build a json document' do
+      json = subject.as_json
+      expect(json.fetch('type')).to eq(agent.type)
+      expect(json.fetch('id')).to eq(agent.id)
+      expect(json.fetch('attributes')).to eq('strategy' => identifier.strategy, 'identifying_value' => identifier.identifying_value)
+      expect(json.fetch('relationships').fetch('identities')).to eq([{ "type" => "netid", "id" => "hello", 'attributes' => {} }])
+      expect(json.fetch('relationships').fetch('verified_identities')).to eq([{ "type" => "netid", "id" => "hello", 'attributes' => {} }])
+    end
+  end
+end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Agent do
 
   it { should delegate_method(:strategy).to(:primary_identifier) }
   it { should delegate_method(:identifying_value).to(:primary_identifier) }
+  it { should delegate_method(:as_json).to(:serializer) }
 
   its(:type) { should eq(described_class::JSON_API_TYPE) }
 

--- a/spec/models/identifier/unverified_spec.rb
+++ b/spec/models/identifier/unverified_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Identifier::Unverified do
   its(:verified?) { should be_falsey }
   its(:attribute_keys) { should be_empty }
   its(:strategy) { should eq("unverified/#{identifier.strategy}") }
+  its(:as_json) { should eq({}) }
   it { should delegate_method(:identifying_value).to(:identifier) }
   it { should delegate_method(:<=>).to(:identifier) }
   it { should delegate_method(:base_strategy).to(:identifier) }

--- a/spec/models/identifier/unverified_spec.rb
+++ b/spec/models/identifier/unverified_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Identifier::Unverified do
   include Cogitate::RSpecMatchers
   it { should contractually_honor(Cogitate::Interfaces::VerifiableIdentifierInterface) }
   its(:verified?) { should be_falsey }
-  its(:attribute_keys) { should be_empty }
   its(:strategy) { should eq("unverified/#{identifier.strategy}") }
   its(:as_json) { should eq({}) }
   it { should delegate_method(:identifying_value).to(:identifier) }

--- a/spec/models/identifier/verified/group_spec.rb
+++ b/spec/models/identifier/verified/group_spec.rb
@@ -15,7 +15,7 @@ class Identifier
       it { should delegate_method(:base_identifying_value).to(:identifier) }
       it { should delegate_method(:base_strategy).to(:identifier) }
       its(:name) { should eq('A Group Name') }
-      its(:attribute_keys) { should be_a(Array) }
+      its(:as_json) { should eq('name' => 'A Group Name', 'description' => nil) }
       its(:strategy) { should eq("verified/#{identifier.strategy}") }
 
       it 'will not obliterate the given identifier if the attributes have an identifier' do

--- a/spec/models/identifier/verified/netid_spec.rb
+++ b/spec/models/identifier/verified/netid_spec.rb
@@ -16,6 +16,7 @@ class Identifier
       it { should delegate_method(:base_strategy).to(:identifier) }
       its(:first_name) { should eq('A First Name') }
       its(:attribute_keys) { should be_a(Array) }
+      its(:as_json) { should be_a(Hash) }
       its(:strategy) { should eq("verified/#{identifier.strategy}") }
 
       it 'will not obliterate the given identifier if the attributes have an identifier' do

--- a/spec/models/identifier/verified_spec.rb
+++ b/spec/models/identifier/verified_spec.rb
@@ -14,7 +14,6 @@ class Identifier
     it { should delegate_method(:base_identifying_value).to(:identifier) }
     it { should delegate_method(:base_strategy).to(:identifier) }
     its(:first_name) { should eq('A First Name') }
-    its(:attribute_keys) { should be_a(Array) }
     its(:strategy) { should eq("verified/#{identifier.strategy}") }
 
     it 'will not obliterate the given identifier if the attributes have an identifier' do

--- a/spec/models/identifier_spec.rb
+++ b/spec/models/identifier_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Identifier do
 
   its(:encoded_id) { should be_a(String) }
   its(:base_strategy) { should eq(subject.strategy) }
-  its(:attribute_keys) { should eq([]) }
   its(:base_identifying_value) { should eq(subject.identifying_value) }
 
   context '#strategy coercion' do

--- a/spec/services/cogitate/services/agent_tokenizer_spec.rb
+++ b/spec/services/cogitate/services/agent_tokenizer_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+require 'cogitate/services/agent_tokenizer'
+require 'jwt'
+
+module Cogitate
+  module Services
+    RSpec.describe AgentTokenizer do
+      let(:agent) { { identifier: 'hello' } }
+      let(:password) { nil }
+      let(:encryption_type) { false }
+      let(:issuer_claim) { "The Man" }
+      subject { described_class.new(agent: agent, password: nil, encryption_type: 'none', issuer_claim: issuer_claim) }
+
+      its(:default_encryption_type) { should eq(Figaro.env.agent_tokenizer_encryption_type) }
+      its(:default_password) { should eq(Figaro.env.agent_tokenizer_private_password) }
+
+      it 'exposes .call as a convenience method' do
+        expect_any_instance_of(described_class).to receive(:call)
+        described_class.call(agent: agent, password: nil, encryption_type: 'none', issuer_claim: issuer_claim)
+      end
+
+      context '#call' do
+        it 'will transform the agent to JSON then encode that JSON via JWT encoding' do
+          expect(subject.call).to be_a(String)
+        end
+
+        it 'will use the default password even though it must first be coerced' do
+          subject = described_class.new(agent: agent)
+          expect(subject.call).to be_a(String)
+        end
+
+        it 'will be decodable via the JWT module' do
+          token = subject.call
+          decoded_token = JWT.decode(token, password, false, 'iss' => issuer_claim, verify_iss: true)
+          expected_token = [subject.send(:payload).stringify_keys, { 'typ' => 'JWT', 'alg' => 'none' }]
+          expect(decoded_token).to eq(expected_token)
+        end
+
+        it 'will be decodable via the JWT module with an enforceable issue' do
+          token = subject.call
+          expect { JWT.decode(token, password, false, 'iss' => 'bogus', verify_iss: true) }.to raise_error(JWT::InvalidIssuerError)
+        end
+      end
+
+      # While it may be odd to test a private method, I want to make sure that its under test regarding its contents.
+      context '#payload' do
+        let(:payload) { subject.send(:payload) }
+        it 'will have a :data key that is a representation of the agent' do
+          expect(payload.fetch(:data)).to eq(agent.as_json)
+        end
+        it 'will have :data and :iss keys' do
+          expect(payload.keys).to eq([:data, :iss])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/cogitate/services/identifier_to_agent_encoder_spec.rb
+++ b/spec/services/cogitate/services/identifier_to_agent_encoder_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_fast_helper'
-require 'cogitate/services/identifier_token_encoder'
+require 'cogitate/services/identifier_to_agent_encoder'
 require 'identifier'
 
 module Cogitate
@@ -23,6 +23,11 @@ module Cogitate
           expect(agent_extractor).to receive(:call).with(identifier: identifier).and_return(agent)
           expect(subject.call).to eq(token)
         end
+      end
+
+      it 'will expose .call as a public convenience method' do
+        expect_any_instance_of(described_class).to receive(:call)
+        described_class.call(identifier: identifier)
       end
     end
   end

--- a/spec/services/cogitate/services/identifier_token_encoder_spec.rb
+++ b/spec/services/cogitate/services/identifier_token_encoder_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_fast_helper'
+require 'cogitate/services/identifier_token_encoder'
+require 'identifier'
+
+module Cogitate
+  module Services
+    RSpec.describe IdentifierToAgentEncoder do
+      let(:identifier) { Identifier.new(strategy: 'netid', identifying_value: 'hello-world') }
+      let(:agent_extractor) { double('Extractor', call: true) }
+      let(:agent_tokenizer) { double('Tokenizer', call: true) }
+      subject { described_class.new(identifier: identifier, agent_extractor: agent_extractor, agent_tokenizer: agent_tokenizer) }
+
+      include Cogitate::RSpecMatchers
+
+      its(:default_agent_extractor) { should respond_to(:call) }
+      its(:default_agent_tokenizer) { should respond_to(:call) }
+
+      context '#call' do
+        it 'will extract the agent then tokenize it' do
+          agent = double('Agent')
+          token = double('Token')
+          expect(agent_tokenizer).to receive(:call).with(agent: agent).and_return(token)
+          expect(agent_extractor).to receive(:call).with(identifier: identifier).and_return(agent)
+          expect(subject.call).to eq(token)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Adding omniauth gem as a dependency

@0fa11bd747abe677c4a794c4f9d0bbf9030d6dd0


## Bundling omniauth

@ee95d197a9f7d82b4e0cdec5fa3d39b3e84ac14c

```console
$ bundle
```

## Adding omniauth-cas gem

@100d97ec70298cfddc684cb0033df05dc13fc0f6

```console
$ bundle
```

## Restoring Rails usage

@c4d5bb56533a1d99105921b81dd635713f878061

It was nice to not load the whole Rails ecosystem, however with
sessions being required for authentication, I wanted to ensure that
I had session handling (which Rails API does not provide a convenient
mechanism).

```console
$ bundle
```

## Adding current user handling for application

@0550a19e104f62b61aee473963d8c883ee61029e


## Adding ability to handle Omniauth callbacks

@c7a618af479fccc3880e8b886f92c4d179b39f85

Exposing this action provides the ability to handle one or more
authentication vectors.

## Adding omniauth initializers

@2a91946ee48a6fea328d78db6d39c9b5afa7482e

For now, I'm leveraging our CAS configuration

## Updating Roadmap

@120d37146033ac6ddf09144e9b5df04c985957f2

[skip ci]

## Adding jwt gem

@92539bcb824a2eb365a990ec9b8abcb23057b7cc

JSON Web Token implementation in Ruby

See https://rubygems.org/gems/jwt
See https://github.com/jwt/ruby-jwt
See https://tools.ietf.org/html/rfc7519

```console
$ bundle
```

## Adding as_json options to identifiers

@e9d7cf15cd1effc19d14cf43d1db046b1b44532e

Yes, I could move those into serializer objects but those data
structure objects are already rather light.

## Adding an Agent::Serializer

@3437b9b82774ec79eb7ddc530cb9548b19469763

Responsible for the serialization logic of an Agent.

## Leveraging Agent#as_json for serialization

@fd6839bf39a5e96da3d068be70b3ac0bbecac76f

The builder is nice, however given that I'm working with JSON, I
can leverage the more immediate and obvious #as_json method

## Removing attribute_keys methods

@6ef35b2d94b8b8895d623cbc6b147e28e60b072f

Preferring instead to use as_json

## Generating Agent token via jwt gem

@2977c3e6054619ea0cbadb6f3e2282ef40255110

The generated token is cryptographically secure and part of the
authentication callback for those wishing to authenticate via
Cogitate. The data payload of the token are not yet complete, but
will look similar to the payload returned via the GET /api/agents
request.

## Adding Sessions#new action

@c3f3aedb40372b17583bc38112916251fc36d784

This action is the external API end point for brokered authentication
via Cogitate. It is responsible for ensuring a well-formed brokerable
request and remembering relevant after authentication information.

## Renaming file to reflect constant

@918d911b2f96de83cbfaa7c4b9349a16b317a46e


## Adding after_authentication_callback handling

@984eea7f2d8ade0b2b0dfa3b60978d42a22adcd7
